### PR TITLE
Three important fixes.

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -8,7 +8,7 @@ Comment: non-numericals are there only to make configuration file more readable.
 Comment: Use 0 as an amount of seconds when you don't want to kick people.
 
 kick_thresholds:
-  - When 81 to 100 players online kick after 60 seconds
+  - When 81 to 500 players online kick after 60 seconds
   - When 51 to 80  players online kick after 120 seconds
   - When 2  to 50  players online kick after 240 seconds
   - When 1  to 1  players online kick after 3600 seconds  

--- a/src/com/github/Kraken3/AFKPGC/AFKPGC.java
+++ b/src/com/github/Kraken3/AFKPGC/AFKPGC.java
@@ -28,7 +28,7 @@ public class AFKPGC extends JavaPlugin {
 		// Reads Config.yml - false as an answer indicated unrecoverable error
 		AFKPGC.enabled = ConfigurationReader.readConfig();
 		if (!AFKPGC.enabled)
-			logger.log(logger.getLevel(), "Plugin is not running");
+			logger.warning("Plugin is not running");
 
 		getServer().getPluginManager()
 				.registerEvents(new EventHandlers(), this);
@@ -57,7 +57,7 @@ public class AFKPGC extends JavaPlugin {
 					}
 				}, 0, 6000L);
 		
-		logger.log(logger.getLevel(), "AFK Player Garbage Collector has been enabled");
+		logger.info("AFK Player Garbage Collector has been enabled");
 	}
 
 	@Override
@@ -65,7 +65,7 @@ public class AFKPGC extends JavaPlugin {
 		BotDetector.freeEveryone(); // players wont get freed if the server
 									// crashed, should the bans of this plugin
 									// also be stored in an external file?
-		logger.log(logger.getLevel(), "AFK Player Garbage Collector has been disabled");
+		logger.info( "AFK Player Garbage Collector has been disabled");
 	}
 
 	public static void removerPlayer(UUID uuid) {
@@ -76,7 +76,7 @@ public class AFKPGC extends JavaPlugin {
 	public static LastActivity addPlayer(Player p) {
 		if (p == null)
 			return null;
-		if (AFKPGC.immuneAccounts.contains(p.getUniqueId())) {
+		if (AFKPGC.immuneAccounts != null && AFKPGC.immuneAccounts.contains(p.getUniqueId())) {
 			return null;
 		}
 		UUID uuid = p.getUniqueId();

--- a/src/com/github/Kraken3/AFKPGC/BotDetector.java
+++ b/src/com/github/Kraken3/AFKPGC/BotDetector.java
@@ -139,9 +139,7 @@ public class BotDetector implements Runnable {
 								addToBanfile(lastRoundSuspectName);
 								suspectedBotters.remove(lastRoundSuspectName);
 							}
-							AFKPGC.logger
-									.log(AFKPGC.logger.getLevel(),
-											"The player "
+							AFKPGC.logger.info("The player "
 													+ lastRoundSuspectName
 													+ " causes lag and is a repeated offender,"
 													+ " kicking him resulted in a TPS improvement of "
@@ -153,9 +151,7 @@ public class BotDetector implements Runnable {
 
 						} else {
 							suspectedBotters.add(lastRoundSuspectName);
-							AFKPGC.logger
-									.log(AFKPGC.logger.getLevel(),
-											"The player "
+							AFKPGC.logger.info( "The player "
 													+ lastRoundSuspectName
 													+ " is suspected to cause lag,"
 													+ " kicking him resulted in a TPS improvement of "
@@ -201,8 +197,7 @@ public class BotDetector implements Runnable {
 			bufferedWriter.newLine();
 			bufferedWriter.close();
 		} catch (IOException e) {
-			AFKPGC.logger.log(AFKPGC.logger.getLevel(),
-					"Error while trying to add " + name
+			AFKPGC.logger.warning("Error while trying to add " + name
 							+ " to the banned players file");
 		}
 	}
@@ -221,8 +216,7 @@ public class BotDetector implements Runnable {
 			}
 			bufferedReader.close();
 		} catch (IOException ex) {
-			AFKPGC.logger.log(AFKPGC.logger.getLevel(),
-					"Error while trying to parse the banned players file");
+			AFKPGC.logger.warning("Error while trying to parse the banned players file");
 		}
 	}
 

--- a/src/com/github/Kraken3/AFKPGC/ConfigurationReader.java
+++ b/src/com/github/Kraken3/AFKPGC/ConfigurationReader.java
@@ -5,6 +5,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
 
 import org.bukkit.configuration.file.FileConfiguration;
 
@@ -18,6 +20,8 @@ public class ConfigurationReader {
 		FileConfiguration conf = AFKPGC.plugin.getConfig();
 
 		int max_players = AFKPGC.plugin.getServer().getMaxPlayers();
+		AFKPGC.logger.info("Server reports maximum of " + max_players + " players");
+
 		int[] kickThresholds = new int[max_players];
 		for (int i = 0; i < max_players; i++)
 			kickThresholds[i] = -1;
@@ -28,6 +32,7 @@ public class ConfigurationReader {
 			nums[0] = nums[1] = nums[2] = -1;
 			parseNaturals(s, nums);
 			int min = nums[0], max = nums[1], t = nums[2];
+			AFKPGC.logger.info("Between " + min + " and " + max + " kick after " + t + " seconds.");
 			if (min > max || min < 1 || max < 1 || t < 0) {
 				AFKPGC.logger.warning("Configuration file error: " + s);
 				return false;
@@ -39,20 +44,42 @@ public class ConfigurationReader {
 						AFKPGC.logger.config("Previously defined threshold getting redefined in: "
 										+ s);
 					kickThresholds[i - 1] = t;
+				} else {
+					break; // don't keep going if we're not gonna use it.
 				}
 			}
 		}
 
 		boolean foundEmptyThreshold = false;
+		int gapStart = -1;
+		int gapEnd = -1;
 		for (int i = 0; i < max_players; i++) {
 			if (kickThresholds[i] == -1) {
-				AFKPGC.logger.warning("Configuration file incomplete - plugin doesn't know when to kick players when there are "
-										+ i + 1 + " players online");
+				if (gapStart > -1) {
+					gapEnd = i;
+				} else {
+					gapStart = i;
+					gapEnd = i;
+				}
 				foundEmptyThreshold = true;
+			} else if (gapStart > -1) {
+				AFKPGC.logger.warning("Configuration file incomplete - plugin doesn't know when to kick players when there are between "
+						+ (gapStart + 1) + " and "
+						+ (gapEnd + 1) + " players online");
+				gapStart = -1;
+				gapEnd = -1;
 			}
+
 		}
-		if (foundEmptyThreshold)
+
+		if (foundEmptyThreshold) {
+			if (gapStart > -1) {
+				AFKPGC.logger.warning("Configuration file incomplete - plugin doesn't know when to kick players when there are between "
+						+ (gapStart + 1) + " and "
+						+ (gapEnd + 1) + " players online");
+			}
 			return false;
+		}
 
 		ArrayList<Warning> warnings = new ArrayList<Warning>();
 		ktl = conf.getStringList("warnings");
@@ -106,25 +133,22 @@ public class ConfigurationReader {
 		return true;
 	}
 
+	/**
+	 * attempt to fill numbers but quietly fail.
+	 */
 	public static void parseNaturals(String str, int[] numbers) {
-		int len = str.length();
-		int numberIndex = 0;
-		int maxIndex = numbers.length;
-		int currentNumber = 0;
-		boolean numberStarted = false;
-
-		for (int i = 0; i < len; i++) {
-			char c = str.charAt(i);
-			if (c >= '0' && c <= '9') {
-				numberStarted = true;
-				currentNumber = currentNumber * 10 + (c - '0');
-				numbers[numberIndex] = currentNumber;
-			} else if (numberStarted) {
-				numberStarted = false;
-				currentNumber = 0;
-				numberIndex++;
-				if (numberIndex == maxIndex)
-					return;
+		Pattern num = Pattern.compile("[0-9]+");
+		Matcher findnum = num.matcher(str);
+		for (int i = 0; i < numbers.length; i++) {
+			if (findnum.find()) {
+				String cmatch = findnum.group();
+				try {
+					numbers[i] = Integer.valueOf(cmatch);
+				} catch (NumberFormatException nfe) {
+					break;
+				}
+			} else {
+				break;
 			}
 		}
 	}

--- a/src/com/github/Kraken3/AFKPGC/ConfigurationReader.java
+++ b/src/com/github/Kraken3/AFKPGC/ConfigurationReader.java
@@ -29,16 +29,14 @@ public class ConfigurationReader {
 			parseNaturals(s, nums);
 			int min = nums[0], max = nums[1], t = nums[2];
 			if (min > max || min < 1 || max < 1 || t < 0) {
-				AFKPGC.logger.log(AFKPGC.logger.getLevel(),
-						"Configuration file error: " + s);
+				AFKPGC.logger.warning("Configuration file error: " + s);
 				return false;
 			}
 
 			for (int i = min; i <= max; i++) {
 				if (i <= max_players) {
 					if (kickThresholds[i - 1] != -1)
-						AFKPGC.logger.log(AFKPGC.logger.getLevel(),
-								"Previously defined threshold getting redefined in: "
+						AFKPGC.logger.config("Previously defined threshold getting redefined in: "
 										+ s);
 					kickThresholds[i - 1] = t;
 				}
@@ -48,9 +46,7 @@ public class ConfigurationReader {
 		boolean foundEmptyThreshold = false;
 		for (int i = 0; i < max_players; i++) {
 			if (kickThresholds[i] == -1) {
-				AFKPGC.logger
-						.log(AFKPGC.logger.getLevel(),
-								"Configuration file incomplete - plugin doesn't know when to kick players when there are "
+				AFKPGC.logger.warning("Configuration file incomplete - plugin doesn't know when to kick players when there are "
 										+ i + 1 + " players online");
 				foundEmptyThreshold = true;
 			}

--- a/src/com/github/Kraken3/AFKPGC/EventHandlers.java
+++ b/src/com/github/Kraken3/AFKPGC/EventHandlers.java
@@ -13,82 +13,110 @@ class EventHandlers implements Listener {
 
 	@EventHandler
 	public void PlayerKickEvent(PlayerQuitEvent event) {
-		AFKPGC.removerPlayer(event.getPlayer().getUniqueId());
+		if (AFKPGC.enabled) {
+			AFKPGC.removerPlayer(event.getPlayer().getUniqueId());
+		}
 	}
 
 	@EventHandler
 	public void onPlayerQuitEvent(PlayerQuitEvent event) {
-		AFKPGC.removerPlayer(event.getPlayer().getUniqueId());
+		if (AFKPGC.enabled) {
+			AFKPGC.removerPlayer(event.getPlayer().getUniqueId());
+		}
 	}
 
 	public void registerActivity(Player p) {
-		AFKPGC.addPlayer(p);
+		if (AFKPGC.enabled) {
+			AFKPGC.addPlayer(p);
+		}
 	}
 
 	// EVENTS THAT REGISTER PLAYER ACTIVITY
 
 	@EventHandler
 	public void PlayerJoinEvent(PlayerLoginEvent event) {
-		registerActivity(event.getPlayer());
+		if (AFKPGC.enabled) {
+			registerActivity(event.getPlayer());
+		}
 	}
 
 	// seemingly duplicate events are here for resiliency/defensive programming
 	// as the plugin used to crash for some unobvious reason. I hate it too.
 	@EventHandler
 	public void onPlayerLogin(PlayerLoginEvent event) {
-		registerActivity(event.getPlayer());
+		if (AFKPGC.enabled) {
+			registerActivity(event.getPlayer());
+		}
 	}
 
 	@EventHandler
 	public void onPlayerMoveEvent(PlayerMoveEvent event) {
-		registerActivity(event.getPlayer());
+		if (AFKPGC.enabled) {
+			registerActivity(event.getPlayer());
+		}
 	}
 
 	@EventHandler
 	public void onPlayerChatEvent(PlayerChatEvent event) {
-		if (BotDetector.acceptableTPS < TpsReader.getTPS()) {
+		if (AFKPGC.enabled && BotDetector.acceptableTPS < TpsReader.getTPS()) {
 			registerActivity(event.getPlayer());
 		}
 	}
 
 	@EventHandler
 	public void onPlayerInteractEvent(PlayerInteractEvent event) {
-		registerActivity(event.getPlayer());
+		if (AFKPGC.enabled) {
+			registerActivity(event.getPlayer());
+		}
 	}
 
 	@EventHandler
 	public void onPlayerDropItemEvent(PlayerDropItemEvent event) {
-		registerActivity(event.getPlayer());
+		if (AFKPGC.enabled) {
+			registerActivity(event.getPlayer());
+		}
 	}
 
 	@EventHandler
 	public void onPlayerToggleSneakEvent(PlayerToggleSneakEvent event) {
-		registerActivity(event.getPlayer());
+		if (AFKPGC.enabled) {
+			registerActivity(event.getPlayer());
+		}
 	}
 
 	@EventHandler
 	public void onPlayerItemHeldEvent(PlayerItemHeldEvent event) {
-		registerActivity(event.getPlayer());
+		if (AFKPGC.enabled) {
+			registerActivity(event.getPlayer());
+		}
 	}
 
 	@EventHandler
 	public void onPlayerChangedWorldEvent(PlayerChangedWorldEvent event) {
-		registerActivity(event.getPlayer());
+		if (AFKPGC.enabled) {
+			registerActivity(event.getPlayer());
+		}
 	}
 
 	@EventHandler
 	public void onEnchantItemEvent(EnchantItemEvent event) {
-		registerActivity(event.getEnchanter().getPlayer());
+		if (AFKPGC.enabled) {
+			registerActivity(event.getEnchanter().getPlayer());
+		}
 	}
 
 	@EventHandler
 	public void onPrepareItemEnchantEvent(PrepareItemEnchantEvent event) {
-		registerActivity(event.getEnchanter().getPlayer());
+		if (AFKPGC.enabled) {
+			registerActivity(event.getEnchanter().getPlayer());
+		}
 	}
 
 	@EventHandler
 	public void onInventoryClickEvent(InventoryClickEvent event) {
-		registerActivity(Bukkit.getPlayer(event.getWhoClicked().getName()));
+		if (AFKPGC.enabled) {
+			registerActivity(Bukkit.getPlayer(event.getWhoClicked().getName()));
+		}
 	}
 
 }

--- a/src/com/github/Kraken3/AFKPGC/Kicker.java
+++ b/src/com/github/Kraken3/AFKPGC/Kicker.java
@@ -25,7 +25,7 @@ public class Kicker implements Runnable {
 								p.sendMessage("AFKPGC is alive");
 							}
 						} else {
-							AFKPGC.logger.log(AFKPGC.logger.getLevel(),"AFKPGC is alive");
+							AFKPGC.logger.finest("AFKPGC is alive");
 						}
 					}
 					amIStillAlivePlayer = null;
@@ -78,7 +78,7 @@ public class Kicker implements Runnable {
 					   AFKPGC.removerPlayer(i);						   
 					   int t = (int)((LastActivity.currentTime - la.timeOfLastActivity)/1000);
 					   
-					   AFKPGC.logger.log(AFKPGC.logger.getLevel(),i+" kicked for being AFK for "+CommandHandler.readableTimeSpan(t));
+					   AFKPGC.logger.info(i+" kicked for being AFK for "+CommandHandler.readableTimeSpan(t));
 				   }	
 			   }
 			   


### PR DESCRIPTION
1) if you have an enabled flag to check, use it. 2) not all log entries are created the same. Do not whiff on this. Every log entry has a relative importance, pick the right one. Let the log level cutoff at the log writer decide what is included, do not use a default value for your logging. 3) Where possible do not assume things that could be null are not null.

These are derived from the following: Plugin on Civtest was disabled. Yet, events were being processed. As well, there was no logging information on _why_ the plugin was disabled, but from behavior and NPE's from event processing, it was due to a config error. Since the config file wasn't outputting anything as all the logging was at the logger's default level (probably TRACE) it was impossible to debug.

Always choose your logging level. Rules of thumb: SEVERE for things that cause the plugin to crash. WARNING for things that cause the plugin to disable or impact its regular function. INFO for stuff that's important to appear in the log. CONFIG for "reading back" configuration options as applied, or verbose general information. FINE or below for method entrance, timing and fine details information.
